### PR TITLE
Bugfix / Everyone is admin

### DIFF
--- a/app/middlewares/authorization.js
+++ b/app/middlewares/authorization.js
@@ -21,7 +21,7 @@ exports.user = {
     isAdministrator: function (req, res, next) {
          if (req.headers.authorization) {
             jwt.verify(req.headers.authorization, 'tokenSecret', function (err, decoded) {
-                if (decoded._doc && decoded._doc.isAdmin || !err)
+                if (decoded._doc && decoded._doc.isAdmin)
                   next()
                 else
                     return res.sendStatus(403);


### PR DESCRIPTION
``` javascript
if (decoded._doc && decoded._doc.isAdmin ||  !err)
```

Lors du décodage d'un token, il n'y a pas d'erreur, la condition passe toujours.
